### PR TITLE
Proper (?) destroy/reset implementation

### DIFF
--- a/index.js
+++ b/index.js
@@ -44,6 +44,13 @@ module.exports = function StateProvider(renderer, rootElement, hashRouter) {
 		})
 	}
 
+	function resetStateName(stateName) {
+		activeEmitters[stateName]('destroy')
+		delete activeEmitters[stateName]
+		delete activeStateResolveContent[stateName]
+		return resetDom(activeDomApis[stateName])
+	}
+
 	function getChildElementForStateName(stateName) {
 		return new Promise(function(resolve) {
 			var parent = prototypalStateHolder.getParent(stateName)
@@ -145,6 +152,8 @@ module.exports = function StateProvider(renderer, rootElement, hashRouter) {
 				extend(activeStateResolveContent, stateResolveResultsObject)
 
 				return series(reverse(stateChanges.destroy), destroyStateName).then(function() {
+					return series(reverse(stateChanges.change), resetStateName)
+				}).then(function() {
 					return renderAll(stateChanges.create).then(activateAll)
 				})
 			}))

--- a/index.js
+++ b/index.js
@@ -202,11 +202,9 @@ module.exports = function StateProvider(renderer, rootElement, hashRouter) {
 	}
 
 	function getDestinationUrl(stateName, parameters) {
-		return new Promise(function(resolve, reject) {
-			resolve(prototypalStateHolder.guaranteeAllStatesExist(stateName).then(function() {
-				var route = prototypalStateHolder.buildFullStateRoute(stateName)
-				return buildPath(route, parameters || {})
-			}))
+		return prototypalStateHolder.guaranteeAllStatesExist(stateName).then(function() {
+			var route = prototypalStateHolder.buildFullStateRoute(stateName)
+			return buildPath(route, parameters || {})
 		})
 	}
 

--- a/readme.md
+++ b/readme.md
@@ -86,7 +86,6 @@ If a state change is triggered during a state transition, it is queued and appli
 
 # TODO
 
-- states that are "change"ing should have reset called in the renderer, and destroy/activate called on the context, but they should NOT be destroyed in the DOM.
 - the ability to set an "error" state to go to on errors
 
 License

--- a/state-state.js
+++ b/state-state.js
@@ -54,7 +54,7 @@ module.exports = function StateState() {
 			if (route && route[route.length - 1] !== '/' && state.route[0] !== '/') {
 				route = route + '/'
 			}
-			return route + state.route
+			return route + (state.route || '')
 		}, '')
 	}
 

--- a/test/dom-interaction.js
+++ b/test/dom-interaction.js
@@ -1,0 +1,81 @@
+var test = require('tape')
+var getTestState = require('./helpers/test-state-factory')
+
+test('All dom functions called in order', function(t) {
+	function noop() {}
+
+	var actions = []
+
+	var renderer = {
+		render: function render(element, template, cb) {
+			actions.push('render ' + template + ' on ' + element)
+			cb(null, template)
+		},
+		reset: function reset(renderedTemplateApi, cb) {
+			actions.push('reset ' + renderedTemplateApi)
+			cb()
+		},
+		destroy: function destroy(renderedTemplateApi, cb) {
+			actions.push('destroy ' + renderedTemplateApi)
+			cb()
+		},
+		getChildElement: function getChildElement(renderedTemplateApi, cb) {
+			actions.push('getChild ' + renderedTemplateApi)
+			cb(null, renderedTemplateApi + ' child')
+		}
+	}
+
+	var state = getTestState(t, renderer)
+
+	var expectedActions = [
+		'render topTemplate on body',
+		'getChild topTemplate',
+		'render topFirstTemplate on topTemplate child',
+		'activate top',
+		'activate top.first',
+		'destroy topFirstTemplate',
+		'reset topTemplate',
+		'getChild topTemplate',
+		'render topSecondTemplate on topTemplate child',
+		'activate top',
+		'activate top.second'
+	]
+
+	t.plan(expectedActions.length)
+
+	state.stateRouter.addState({
+		name: 'top',
+		template: 'topTemplate',
+		querystringParameters: ['myFancyParam'],
+		activate: function() {
+			actions.push('activate top')
+		}
+	})
+
+	state.stateRouter.addState({
+		name: 'top.first',
+		template: 'topFirstTemplate',
+		route: '/first',
+		activate: function() {
+			actions.push('activate top.first')
+			state.stateRouter.go('top.second', {
+				myFancyParam: 'groovy dude'
+			})
+		}
+	})
+
+	state.stateRouter.addState({
+		name: 'top.second',
+		template: 'topSecondTemplate',
+		route: '/second',
+		activate: function() {
+			actions.push('activate top.second')
+			expectedActions.forEach(function(planned, index) {
+				t.equal(actions[index], planned, planned)
+			})
+			t.end()
+		}
+	})
+
+	state.stateRouter.go('top.first')
+})


### PR DESCRIPTION
Changing states now have "reset" called on their DOM API, and have "destroy" emitted on their context.

Also snuck in the feature where routes strings can be empty now.