### PR TITLE
Don't run browserstack tests on PRs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ node_js:
 sudo: false
 script:
   - npm test
-  - npm run browserstack
+  - '[ "${TRAVIS_PULL_REQUEST}" = "false" ] && npm run browserstack || false'
 env:
   global:
   - secure: A86CL+EBtITETRILi3mE2O5G2JLGdzWQ0hB8oIamIx36qZyfbSO69klBwoiOr5xvnh7iWuCakARG738cg9k7umrYsN+a1YSxCJwB8A33xrX+8/BroKElIV8M58WluHokYB+TZh/SLJ1CpCAZobc3B1YKzdeTZQiQSOJ8d9jB+Mw=


### PR DESCRIPTION
Browserstack tests can't run in Pull Requests because of [travis' security restrictions](http://docs.travis-ci.com/user/pull-requests/#Security-Restrictions-when-testing-Pull-Requests).