### PR TITLE
Default route parameters

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,7 @@
+# [5.14.0](https://github.com/TehShrike/abstract-state-router/releases/tag/v5.14.0)
+
+- functional: replaced the `defaultQuerystringParameters` property on states with `defaultParameters`, which applies to both querystring and route parameters.  If you don't specify `defaultParameters`, `defaultQuerystringParameters` will be checked too (though it will now apply to route parameters as well).  [#91](https://github.com/TehShrike/abstract-state-router/issues/91)
+
 # [5.13.0](https://github.com/TehShrike/abstract-state-router/releases/tag/v5.13.0)
 
 - functional: made `stateName` optional for `go`/`replace`/`makePath` [#83](https://github.com/TehShrike/abstract-state-router/pull/83)

--- a/index.js
+++ b/index.js
@@ -17,7 +17,7 @@ var buildPath = require('page-path-builder')
 
 require('native-promise-only/npo')
 
-var expectedPropertiesOfAddState = ['name', 'route', 'defaultChild', 'data', 'template', 'resolve', 'activate', 'querystringParameters', 'defaultQuerystringParameters']
+var expectedPropertiesOfAddState = ['name', 'route', 'defaultChild', 'data', 'template', 'resolve', 'activate', 'querystringParameters', 'defaultQuerystringParameters', 'defaultParameters']
 
 module.exports = function StateProvider(makeRenderer, rootElement, stateRouterOptions) {
 	var prototypalStateHolder = StateState()
@@ -224,7 +224,7 @@ module.exports = function StateProvider(makeRenderer, rootElement, stateRouterOp
 		return promiseMe(prototypalStateHolder.guaranteeAllStatesExist, newStateName)
 		.then(function applyDefaultParameters() {
 			var state = prototypalStateHolder.get(newStateName)
-			var defaultParams = state.defaultQuerystringParameters || {}
+			var defaultParams = state.defaultParameters || state.defaultQuerystringParameters || {}
 			var needToApplyDefaults = Object.keys(defaultParams).some(function missingParameterValue(param) {
 				return !parameters[param]
 			})
@@ -317,7 +317,7 @@ module.exports = function StateProvider(makeRenderer, rootElement, stateRouterOp
 		var destinationStateName = stateName === null ? getGuaranteedPreviousState().name : stateName
 
 		var destinationState = prototypalStateHolder.get(destinationStateName) || {}
-		var defaultParams = destinationState.defaultQuerystringParameters
+		var defaultParams = destinationState.defaultParameters || destinationState.defaultQuerystringParameters
 
 		parameters = extend(defaultParams, parameters)
 

--- a/index.js
+++ b/index.js
@@ -314,10 +314,15 @@ module.exports = function StateProvider(makeRenderer, rootElement, stateRouterOp
 			parameters = extend(getGuaranteedPreviousState().parameters, parameters)
 		}
 
-		var destinationState = stateName === null ? getGuaranteedPreviousState().name : stateName
+		var destinationStateName = stateName === null ? getGuaranteedPreviousState().name : stateName
 
-		prototypalStateHolder.guaranteeAllStatesExist(destinationState)
-		var route = prototypalStateHolder.buildFullStateRoute(destinationState)
+		var destinationState = prototypalStateHolder.get(destinationStateName) || {}
+		var defaultParams = destinationState.defaultQuerystringParameters
+
+		parameters = extend(defaultParams, parameters)
+
+		prototypalStateHolder.guaranteeAllStatesExist(destinationStateName)
+		var route = prototypalStateHolder.buildFullStateRoute(destinationStateName)
 		return buildPath(route, parameters || {})
 	}
 

--- a/readme.md
+++ b/readme.md
@@ -53,7 +53,7 @@ Possible properties of the `options` object are:
 - `router` defaults to an instance of a [hash brown router](https://github.com/TehShrike/hash-brown-router/).  The abstract-state-router unit tests use the [hash brown router stub](https://github.com/TehShrike/hash-brown-router/#testability).  To use pushState, pass in a hash brown router created with [sausage-router](https://github.com/TehShrike/sausage-router).
 - `throwOnError` defaults to true, because you get way better stack traces in Chrome when you throw than if you `console.log(err)` or emit `'error'` events.  The unit tests disable this.
 
-## stateRouter.addState({name, route, defaultChild, data, template, resolve, activate, querystringParameters, defaultQuerystringParameters})
+## stateRouter.addState({name, route, defaultChild, data, template, resolve, activate, querystringParameters, defaultParameters})
 
 The addState function takes a single object of options. All of them are optional, unless stated otherwise.
 
@@ -73,7 +73,9 @@ The addState function takes a single object of options. All of them are optional
 
 `querystringParameters` is an array of query string parameters that will be watched by this state.
 
-`defaultQuerystringParameters` is an object whose properties should correspond to parameters defined in the `querystringParameters` option.  Whatever values you supply here will be used as the defaults in case the url does not contain any value for that parameter.
+`defaultParameters` is an object whose properties should correspond to parameters defined in the `querystringParameters` option or the route parameters.  Whatever values you supply here will be used as the defaults in case the url does not contain any value for that parameter.
+
+For backwards compatibility reasons, `defaultQuerystringParameters` will work as well (though it does not function any differently).
 
 ### resolve(data, parameters, callback(err, content).redirect(stateName, [stateParameters]))
 

--- a/test/default-params.js
+++ b/test/default-params.js
@@ -48,39 +48,60 @@ test('default querystring parameters', function(tt) {
 })
 
 test('race conditions on redirects', function(t) {
-		var state = getTestState(t)
-		var stateRouter = state.stateRouter
-		t.plan(4)
+	var state = getTestState(t)
+	var stateRouter = state.stateRouter
+	t.plan(4)
 
-		stateRouter.addState({
-			name: 'state1',
-			route: '/state1',
-			template: {},
-			querystringParameters: [ 'wat', 'much' ],
-			defaultQuerystringParameters: { wat: 'lol', much: 'neat' },
-			activate: function(context) {
-				t.deepEqual({ wat: 'lol', much: 'neat' }, context.parameters)
-				t.equal(state.location.get(), '/state1?wat=lol&much=neat')
+	stateRouter.addState({
+		name: 'state1',
+		route: '/state1',
+		template: {},
+		querystringParameters: [ 'wat', 'much' ],
+		defaultQuerystringParameters: { wat: 'lol', much: 'neat' },
+		activate: function(context) {
+			t.deepEqual({ wat: 'lol', much: 'neat' }, context.parameters)
+			t.equal(state.location.get(), '/state1?wat=lol&much=neat')
 
-				stateRouter.go('state2', { wat: 'waycool', much: 'awesome', hi: 'world' }) //does not redirect
-			}
-		})
+			stateRouter.go('state2', { wat: 'waycool', much: 'awesome', hi: 'world' }) //does not redirect
+		}
+	})
 
-		stateRouter.addState({
-			name: 'state2',
-			route: '/state2',
-			template: {},
-			querystringParameters: [ 'wat', 'much' ],
-			defaultQuerystringParameters: { wat: 'lol', much: 'neat' },
-			activate: function(context) {
-				t.deepEqual({ wat: 'waycool', much: 'awesome', hi: 'world' }, context.parameters)
-				t.equal(state.location.get(), '/state2?wat=waycool&much=awesome&hi=world')
+	stateRouter.addState({
+		name: 'state2',
+		route: '/state2',
+		template: {},
+		querystringParameters: [ 'wat', 'much' ],
+		defaultQuerystringParameters: { wat: 'lol', much: 'neat' },
+		activate: function(context) {
+			t.deepEqual({ wat: 'waycool', much: 'awesome', hi: 'world' }, context.parameters)
+			t.equal(state.location.get(), '/state2?wat=waycool&much=awesome&hi=world')
 
-				t.end()
-			}
-		})
+			t.end()
+		}
+	})
 
 
-		stateRouter.go('state1', {}) //redirects
+	stateRouter.go('state1', {}) //redirects
 
+})
+
+test('default parameters should work for route params too', function(t) {
+	var state = getTestState(t)
+	var stateRouter = state.stateRouter
+
+	stateRouter.addState({
+		name: 'state1',
+		route: '/state1/:yarp',
+		template: {},
+		querystringParameters: [ 'wat' ],
+		defaultQuerystringParameters: { wat: 'lol', yarp: 'neat' },
+		activate: function(context) {
+			t.deepEqual({ wat: 'lol', yarp: 'neat' }, context.parameters)
+			t.equal(state.location.get(), '/state1/neat?wat=lol')
+
+			t.end()
+		}
+	})
+
+	stateRouter.go('state1', {}) //redirects
 })

--- a/test/default-params.js
+++ b/test/default-params.js
@@ -123,3 +123,79 @@ test('default parameters should work for route params too', function(t) {
 	testWithPropertyName('defaultParameters')
 	testWithPropertyName('defaultQuerystringParameters')
 })
+
+test('default parameters should work for default child route params', function(t) {
+	function testWithPropertyName(property) {
+		t.test(property, function(tt) {
+			var state = getTestState(tt)
+			var stateRouter = state.stateRouter
+
+			stateRouter.addState({
+				name: 'state1',
+				route: '/state1',
+				defaultChild: 'child1',
+				template: {}
+			})
+
+			var asrState = {
+				name: 'state1.child1',
+				route: '/:yarp',
+				template: {},
+				querystringParameters: [ 'wat' ],
+				activate: function(context) {
+					tt.deepEqual({ wat: 'lol', yarp: 'neat' }, context.parameters)
+					tt.equal(state.location.get(), '/state1/neat?wat=lol')
+
+					tt.end()
+				}
+			}
+
+			asrState[property] = { wat: 'lol', yarp: 'neat' }
+
+			stateRouter.addState(asrState)
+
+			stateRouter.go('state1', {})
+		})
+	}
+
+	testWithPropertyName('defaultParameters')
+	testWithPropertyName('defaultQuerystringParameters')
+})
+
+test('default parameters on parent states should apply to child state routes', function(t) {
+	function testWithPropertyName(property) {
+		t.test(property, function(tt) {
+			var state = getTestState(tt)
+			var stateRouter = state.stateRouter
+
+			var parentState = {
+				name: 'state1',
+				route: '/state1',
+				defaultChild: 'child1',
+				template: {}
+			}
+
+			parentState[property] = { wat: 'lol', yarp: 'neat' }
+
+			stateRouter.addState(parentState)
+
+			stateRouter.addState({
+				name: 'state1.child1',
+				route: '/:yarp',
+				template: {},
+				querystringParameters: [ 'wat' ],
+				activate: function(context) {
+					tt.deepEqual({ wat: 'lol', yarp: 'neat' }, context.parameters)
+					tt.equal(state.location.get(), '/state1/neat?wat=lol')
+
+					tt.end()
+				}
+			})
+
+			stateRouter.go('state1', {})
+		})
+	}
+
+	testWithPropertyName('defaultParameters')
+	testWithPropertyName('defaultQuerystringParameters')
+})


### PR DESCRIPTION
This fixes #91 - default parameters are applied to route parameters as well as querystring parameters, and `defaultQuerystringParameters` is deprecated in favor of `defaultParameters`.

Peer review would be appreciated!