### PR TITLE
Bump hash-brown-router dependency to 3.0.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,8 @@
 language: node_js
 node_js:
-  - "0.12"
   - "4"
   - "6"
+  - "7"
 sudo: false
 script:
   - npm test

--- a/index.js
+++ b/index.js
@@ -34,7 +34,7 @@ module.exports = function StateProvider(makeRenderer, rootElement, stateRouterOp
 		stateRouterOptions.router = newHashBrownRouter(defaultRouterOptions)
 	}
 
-	stateRouterOptions.router.setDefault(function(route, parameters) {
+	stateRouterOptions.router.on('not found', function(route, parameters) {
 		stateProviderEmitter.emit('routeNotFound', route, parameters)
 	})
 

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
   "homepage": "https://github.com/TehShrike/abstract-state-router",
   "dependencies": {
     "combine-arrays": "~1.0.2",
-    "hash-brown-router": "~1.5.0",
+    "hash-brown-router": "~3.0.1",
     "native-promise-only": "0.8.1",
     "page-path-builder": "~1.0.3",
     "path-to-regexp-with-reversible-keys": "~1.0.3",

--- a/readme.md
+++ b/readme.md
@@ -50,7 +50,7 @@ The `rootElement` is the element where the first-generation states will be creat
 Possible properties of the `options` object are:
 
 - `pathPrefix` defaults to `'#'`.  If you're using HTML5 routing/pushState, you'll most likely want to set this to an empty string.
-- `router` defaults to an instance of a [hash brown router](https://github.com/TehShrike/hash-brown-router/).  The abstract-state-router unit tests use the [hash brown router stub](https://github.com/TehShrike/hash-brown-router/#testability).  To use pushState, pass in a hash brown router created with [sausage-router](https://github.com/TehShrike/sausage-router).
+- `router` defaults to an instance of a [hash brown router@3.x](https://github.com/TehShrike/hash-brown-router/).  The abstract-state-router unit tests use the [hash brown router stub](https://github.com/TehShrike/hash-brown-router/#testability).  To use pushState, pass in a hash brown router created with [sausage-router](https://github.com/TehShrike/sausage-router).
 - `throwOnError` defaults to true, because you get way better stack traces in Chrome when you throw than if you `console.log(err)` or emit `'error'` events.  The unit tests disable this.
 
 ## stateRouter.addState({name, route, defaultChild, data, template, resolve, activate, querystringParameters, defaultParameters})


### PR DESCRIPTION
Fixes #90

The hash-brown-router dependency injection API was never really defined in the readme or used anywhere, so I think I'm fine with just a feature version bump for this.

Really, eventually the location object that hash-brown-router uses (implemented by sausage-router) should just be its own module, and _that's_ what should be passed in to abstract-state-router.

But whatevs.
