### PR TITLE
Bumping hash-brown-router dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
   "homepage": "https://github.com/TehShrike/abstract-state-router",
   "dependencies": {
     "combine-arrays": "~1.0.2",
-    "hash-brown-router": "~3.0.2",
+    "hash-brown-router": "~3.1.0",
     "native-promise-only": "0.8.1",
     "page-path-builder": "~1.0.3",
     "path-to-regexp-with-reversible-keys": "~1.0.3",


### PR DESCRIPTION
This hash-brown-router version treats the `/` route as equivalent to an empty string route, and gets much better rollup compatibility.