### PR TITLE
Fixed an issue with `stateIsActive` that would crash the router

### DIFF
--- a/index.js
+++ b/index.js
@@ -354,7 +354,7 @@ module.exports = function StateProvider(makeRenderer, rootElement, stateRouterOp
 	}
 	stateProviderEmitter.stateIsActive = function stateIsActive(stateName, opts) {
 		var currentState = lastCompletelyLoadedState.get()
-		return (currentState.name === stateName || currentState.name.indexOf(stateName + '.') === 0) && (typeof opts === 'undefined' || Object.keys(opts).every(function matches(key) {
+		return (currentState.name === stateName || currentState.name.indexOf(stateName + '.') === 0) && (opts == null || Object.keys(opts).every(function matches(key) {
 			return opts[key] === currentState.parameters[key]
 		}))
 	}

--- a/test/test.js
+++ b/test/test.js
@@ -283,6 +283,26 @@ test('stateIsActive', function(t) {
 	stateRouter.go('parent.child1', { butts: 'yes' })
 })
 
+test('stateIsActive if opts is null it should be ignored', function(t) {
+	var stateRouter = getTestState(t).stateRouter
+
+	t.plan(1)
+
+	stateRouter.addState({
+		name: 'parent',
+		template: '',
+		route: '/parent',
+	})
+
+	stateRouter.on('stateChangeEnd', function() {
+		t.ok(stateRouter.stateIsActive('parent', null), 'parent is active')
+
+		t.end()
+	})
+
+	stateRouter.go('parent')
+})
+
 test('stateIsActive but states with that substring are not', function(t) {
 	var stateRouter = getTestState(t).stateRouter
 


### PR DESCRIPTION
If `opts` is `null`, this check fails as `typeof null === 'object'`.

This lets users use `null` or `undefined` as params. This probably needs to be a check to ensure that `opts` is a POJO, as some people could *potentially* pass a primitive. There isn't a lot of error throwing for type checking in the project, so something like throwing an error that you must use a POJO may feel out of place.