### PR TITLE
feature: add github workflows to run tests and run browser tests also

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,24 @@
+name: CI
+
+on: [push, pull_request]
+
+jobs:
+  test:
+    name: Node.js v${{ matrix.nodejs }}
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        nodejs: [14]
+    steps:
+    - uses: actions/checkout@master
+      with:
+        fetch-depth: 1
+    - uses: actions/setup-node@v1
+      with:
+        node-version: ${{ matrix.nodejs }}
+    - run: sudo apt-get install xvfb
+    - name: Install and Test
+      run: |
+        npm ci
+        npm run test
+        xvfb-run --auto-servernum npm run test:browser


### PR DESCRIPTION
I only set it to use Node 14 because it's the latest LTS and asr doesn't really target Node anyway 🤷 

Since `tape-run` uses Electron, we need `xvfb` (or similar) to get some window management on `ubuntu-latest` (it doesn't come with one by default).