### PR TITLE
feature: helpful error message when child DOM not found

### DIFF
--- a/index.js
+++ b/index.js
@@ -122,8 +122,10 @@ module.exports = function StateProvider(makeRenderer, rootElement, stateRouterOp
 		return new Promise(resolve => {
 			const parent = prototypalStateHolder.getParent(stateName)
 			if (parent) {
-				const parentDomApi = activeDomApis[parent.name]
-				resolve(getDomChild(parentDomApi))
+				resolve(getDomChild(activeDomApis[parent.name]).then(childDomApi => {
+					if (!childDomApi) return Promise.reject(new Error(`getDomChild returned a falsey element, did you forget to add a place for a child state to go?`))
+					return childDomApi
+				}))
 			} else {
 				resolve(rootElement)
 			}


### PR DESCRIPTION
If you forget to put a child node in, for example in Svelte it would be forgetting to put the `uiView` element, the error that gets thrown is rather cryptic.

The exact error depends on the renderer exactly, but for example in Svelte it looks like this:
<img width="415" alt="image" src="https://user-images.githubusercontent.com/91254/150597470-1c9f44f1-e7e7-462d-9bb8-2d2ef98d59d7.png">

Instead of throwing a cryptic error, we can reject with an error that gets bubbled out to `stateChangeError`.