### PR TITLE
Coerce parameters to strings to see if a state is active

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,7 @@
+# [7.2.0](https://github.com/TehShrike/abstract-state-router/releases/tag/v7.2.0)
+
+- Coerce parameter values to strings for comparison in `stateIsActive` [#151](https://github.com/TehShrike/abstract-state-router/pull/151)
+
 # [7.1.0](https://github.com/TehShrike/abstract-state-router/releases/tag/v7.1.0)
 
 - Give an explicit/useful error message if you forget to add a `ui-view` element to a parent template [#148](https://github.com/TehShrike/abstract-state-router/pull/148)

--- a/index.js
+++ b/index.js
@@ -375,7 +375,7 @@ module.exports = function StateProvider(makeRenderer, rootElement, stateRouterOp
 		const parametersWereNotPassedIn = !parameters
 
 		return stateNameMatches
-			&& (parametersWereNotPassedIn || Object.keys(parameters).every(key => parameters[key]?.toString() === currentState.parameters[key]))
+			&& (parametersWereNotPassedIn || Object.keys(parameters).every(key => parameters[key] + `` === currentState.parameters[key]))
 	}
 
 	const renderer = makeRenderer(stateProviderEmitter)

--- a/index.js
+++ b/index.js
@@ -375,7 +375,7 @@ module.exports = function StateProvider(makeRenderer, rootElement, stateRouterOp
 		const parametersWereNotPassedIn = !parameters
 
 		return stateNameMatches
-			&& (parametersWereNotPassedIn || Object.keys(parameters).every(key => parameters[key] === currentState.parameters[key]))
+			&& (parametersWereNotPassedIn || Object.keys(parameters).every(key => parameters[key]?.toString() === currentState.parameters[key]))
 	}
 
 	const renderer = makeRenderer(stateProviderEmitter)

--- a/readme.md
+++ b/readme.md
@@ -24,9 +24,9 @@ I occasionally have dreams of [a rewrite](https://github.com/TehShrike/abstract-
 
 # Browser compatibility
 
-This project is currently published as CommonJS ES5-compatible code.
+This project is currently published as CommonJS with modern JS syntax.
 
-If you're supporting old browsers, you'll need to use polyfills for `Promise` and `Object.assign`.  Check out [polyfill.io](https://polyfill.io/), it makes life super-easy.
+If you're supporting old browsers, you'll need to compile to whatever older syntax you target and use polyfills for `Promise` and `Object.assign`.  Check out [polyfill.io](https://polyfill.io/) for automatic polyfills, it makes life super-easy.
 
 # Current renderer implementations
 

--- a/test/helpers/test-state-factory.js
+++ b/test/helpers/test-state-factory.js
@@ -1,6 +1,6 @@
 const hashRouterFactory = require(`hash-brown-router`)
 const hashLocationMockFactory = require(`hash-brown-router/hash-location-mock`)
-const stateRouterFactory = require(`../../`)
+const stateRouterFactory = require(`../../index.js`)
 const defaultRouterOptions = require(`../../default-router-options.js`)
 const mockRenderFn = require(`./renderer-mock`)
 

--- a/test/state-is-active.js
+++ b/test/state-is-active.js
@@ -129,3 +129,28 @@ test(`null parameters passed to stateIsActive are equivalent to passing in nothi
 
 	stateRouter.go(`parent.child`, { butts: `yes` })
 })
+
+test(`stateIsActive coerces parameters to strings before comparing them to the querystring`, t => {
+	const stateRouter = getTestState(t).stateRouter
+
+	stateRouter.addState({
+		name: `parent`,
+		template: ``,
+		route: `/parent`,
+	})
+
+	stateRouter.addState({
+		name: `parent.child`,
+		template: ``,
+		route: `/child`,
+	})
+
+	stateRouter.on(`stateChangeEnd`, () => {
+		t.ok(stateRouter.stateIsActive(`parent.child`, { butts: `420` }))
+		t.ok(stateRouter.stateIsActive(`parent.child`, { butts: 420 }))
+		t.notOk(stateRouter.stateIsActive(`parent.child`, { butts: null }))
+		t.end()
+	})
+
+	stateRouter.go(`parent.child`, { butts: 420 })
+})


### PR DESCRIPTION
Since everything gets coerced to a string when it goes into the url, this makes it not a giant pain to do stuff like `asr.stateIsActive('app.my_state', { my_cool_id: 420 })` when you have numeric ids