### PR TITLE
Remove the concept of resetting states

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,15 @@
+# [7.3.0](https://github.com/TehShrike/abstract-state-router/releases/tag/v7.3.0)
+
+Removes the concept of resetting states.
+
+The concept of resetting breaks down if your component library doesn't support
+- slots
+- resetting the state of a component without resetting the contents of slots
+
+For renderers that "reset" states by destroying the existing component and re-constructing it, stuff would break in any case where a parent and child state were both told to reset at once.  Whenever the parent would reset and destroy its part of the DOM, the child would get wiped out.
+
+Existing renderers don't need to change to work with this version of ASR, it's just that their `reset` function won't get called any more.
+
 # [7.2.0](https://github.com/TehShrike/abstract-state-router/releases/tag/v7.2.0)
 
 - Coerce parameter values to strings for comparison in `stateIsActive` [#151](https://github.com/TehShrike/abstract-state-router/pull/151)

--- a/changelog.md
+++ b/changelog.md
@@ -10,6 +10,8 @@ For renderers that "reset" states by destroying the existing component and re-co
 
 Existing renderers don't need to change to work with this version of ASR, it's just that their `reset` function won't get called any more.
 
+The `beforeResetState` and `afterResetState` should not be fired any more.
+
 # [7.2.0](https://github.com/TehShrike/abstract-state-router/releases/tag/v7.2.0)
 
 - Coerce parameter values to strings for comparison in `stateIsActive` [#151](https://github.com/TehShrike/abstract-state-router/pull/151)

--- a/lib/state-change-logic.js
+++ b/lib/state-change-logic.js
@@ -1,23 +1,16 @@
 module.exports = function stateChangeLogic(stateComparisonResults) {
-	let hitChangingState = false
 	let hitDestroyedState = false
 
 	const output = {
 		destroy: [],
-		change: [],
 		create: [],
 	}
 
 	stateComparisonResults.forEach(state => {
-		hitChangingState = hitChangingState || state.stateParametersChanged
-		hitDestroyedState = hitDestroyedState || state.stateNameChanged
+		hitDestroyedState = hitDestroyedState || state.stateNameChanged || state.stateParametersChanged
 
-		if (state.nameBefore) {
-			if (hitDestroyedState) {
-				output.destroy.push(state.nameBefore)
-			} else if (hitChangingState) {
-				output.change.push(state.nameBefore)
-			}
+		if (state.nameBefore && hitDestroyedState) {
+			output.destroy.push(state.nameBefore)
 		}
 
 		if (state.nameAfter && hitDestroyedState) {

--- a/readme.md
+++ b/readme.md
@@ -77,7 +77,7 @@ var createStateRouter = require('abstract-state-router')
 var stateRouter = createStateRouter(makeRenderer, rootElement, options)
 ```
 
-The `makeRenderer` should be a function that returns an object with four properties: render, destroy, getChildElement, and reset.  Documentation is [here](https://github.com/TehShrike/abstract-state-router/blob/master/renderer.md) - see [test/support/renderer-mock.js](https://github.com/TehShrike/abstract-state-router/blob/master/test/helpers/renderer-mock.js) for an example implementation.
+The `makeRenderer` should be a function that returns an object with four properties: render, destroy, and getChildElement.  Documentation is [here](https://github.com/TehShrike/abstract-state-router/blob/master/renderer.md) - see [test/support/renderer-mock.js](https://github.com/TehShrike/abstract-state-router/blob/master/test/helpers/renderer-mock.js) for an example implementation.
 
 The `rootElement` is the element where the first-generation states will be created.
 
@@ -317,8 +317,6 @@ stateRouter.on('routeNotFound', function(route, parameters) {
 
 - `beforeCreateState({state, content, parameters})`
 - `afterCreateState({state, domApi, content, parameters})`
-- `beforeResetState({state, domApi, content, parameters})`
-- `afterResetState({state, domApi, content, parameters})`
 - `beforeDestroyState({state, domApi})`
 - `afterDestroyState({state})`
 
@@ -336,9 +334,8 @@ To run the unit tests:
 - call all resolve functions
 - resolve functions return
 - **NO LONGER AT PREVIOUS STATE**
-- destroy the contexts of all "destroy" and "change" states
+- destroy the contexts of all "destroy" states
 - destroy appropriate dom elements
-- reset "change"ing dom elements
 - call render functions for "create"ed states
 - call all activate functions
 - emit stateChangeEnd

--- a/readme.md
+++ b/readme.md
@@ -180,13 +180,10 @@ stateRouter.addState({
 	route: '/app',
 	template: '',
 	defaultChild: 'tab1',
-	resolve: function(data, parameters, cb) {
-		// Sync or async stuff; just call the callback when you're done
-		isLoggedIn(function(err, isLoggedIn) {
-			cb(err, isLoggedIn)
-		})
+	async resolve(data, parameters) {
+		return isLoggedIn()
 	},
-	activate: function(context) {
+	activate(context) {
 		// Normally, you would set data in your favorite view library
 		var isLoggedIn = context.content
 		var ele = document.getElementById('status')
@@ -199,10 +196,10 @@ stateRouter.addState({
 	data: {},
 	route: '/tab_1',
 	template: '',
-	resolve: function(data, parameters, cb) {
-		getTab1Data(cb)
+	async resolve(data, parameters) {
+		return getTab1Data()
 	},
-	activate: function(context) {
+	activate(context) {
 		document.getElementById('tab').innerText = context.content
 
 		var intervalId = setInterval(function() {
@@ -220,10 +217,10 @@ stateRouter.addState({
 	data: {},
 	route: '/tab_2',
 	template: '',
-	resolve: function(data, parameters, cb) {
-		getTab2Data(cb)
+	async resolve(data, parameters) {
+		return getTab2Data()
 	},
-	activate: function(context) {
+	activate(context) {
 		document.getElementById('tab').innerText = context.content
 	}
 })

--- a/readme.md
+++ b/readme.md
@@ -340,7 +340,6 @@ To run the unit tests:
 # Every state change does this to states
 
 - destroy: states that are no longer active at all.  The contexts are destroyed, and the DOM elements are destroyed.
-- change: states that remain around, but with different parameter values - the DOM sticks around, but the contexts are destroyed and resolve/activate are called again.
 - create: states that weren't active at all before.  The DOM elements are rendered, and resolve/activate are called.
 
 # HTML5/pushState routing

--- a/readme.md
+++ b/readme.md
@@ -77,7 +77,7 @@ var createStateRouter = require('abstract-state-router')
 var stateRouter = createStateRouter(makeRenderer, rootElement, options)
 ```
 
-The `makeRenderer` should be a function that returns an object with four properties: render, destroy, and getChildElement.  Documentation is [here](https://github.com/TehShrike/abstract-state-router/blob/master/renderer.md) - see [test/support/renderer-mock.js](https://github.com/TehShrike/abstract-state-router/blob/master/test/helpers/renderer-mock.js) for an example implementation.
+The `makeRenderer` should be a function that returns an object with these properties: render, destroy, and getChildElement.  Documentation is [here](https://github.com/TehShrike/abstract-state-router/blob/master/renderer.md) - see [test/support/renderer-mock.js](https://github.com/TehShrike/abstract-state-router/blob/master/test/helpers/renderer-mock.js) for an example implementation.
 
 The `rootElement` is the element where the first-generation states will be created.
 

--- a/test/dom-interaction.js
+++ b/test/dom-interaction.js
@@ -36,7 +36,8 @@ test(`All dom functions called in order`, t => {
 		`activate top`,
 		`activate top.first`,
 		`destroy topFirstTemplate`,
-		`reset topTemplate`,
+		`destroy topTemplate`,
+		`render topTemplate on body`,
 		`getChild topTemplate`,
 		`render topSecondTemplate on topTemplate child`,
 		`activate top`,
@@ -73,61 +74,11 @@ test(`All dom functions called in order`, t => {
 		activate() {
 			actions.push(`activate top.second`)
 			expectedActions.forEach((planned, index) => {
-				t.equal(actions[index], planned, planned)
+				t.equal(actions[index], planned, `Action ${index} should be "${planned}"`)
 			})
 			t.end()
 		},
 	})
 
 	state.stateRouter.go(`top.first`)
-})
-
-test(`Supplying a value to reset replaces the active DOM API`, t => {
-	const originalDomApi = {}
-	const domApiAfterReset = {}
-
-	function makeRenderer() {
-		return {
-			render: function render(context, cb) {
-				cb(null, originalDomApi)
-			},
-			reset: function reset(context, cb) {
-				t.equal(originalDomApi, context.domApi)
-				cb(null, domApiAfterReset)
-			},
-			destroy: function destroy(renderedTemplateApi, cb) {
-				cb()
-			},
-			getChildElement: function getChildElement(renderedTemplateApi, cb) {
-				cb()
-			},
-		}
-	}
-
-	const state = getTestState(t, makeRenderer)
-	let firstActivation = true
-
-	state.stateRouter.addState({
-		name: `top`,
-		template: `topTemplate`,
-		querystringParameters: [ `myFancyParam` ],
-		activate(context) {
-			if (firstActivation) {
-				t.equal(context.domApi, originalDomApi)
-				firstActivation = false
-
-				state.stateRouter.go(`top`, {
-					myFancyParam: `new value`,
-				})
-			} else {
-				t.equal(context.domApi, domApiAfterReset)
-				t.end()
-			}
-		},
-	})
-
-
-	state.stateRouter.go(`top`, {
-		myFancyParam: `original value`,
-	})
 })

--- a/test/emitters.js
+++ b/test/emitters.js
@@ -216,7 +216,7 @@ test(`emitting dom api create`, t => {
 			cb(null, originalDomApi)
 		},
 		reset(context, cb) {
-			cb(null)
+			t.ok(false, `Reset should not be called`)
 		},
 		destroy(renderedTemplateApi, cb) {
 			cb(null)
@@ -284,7 +284,7 @@ test(`emitting dom api destroy`, t => {
 			cb(null, originalDomApi)
 		},
 		reset(context, cb) {
-			cb(null)
+			t.ok(false, `Reset should not be called`)
 		},
 		destroy(renderedTemplateApi, cb) {
 			t.ok(beforeEventFired)
@@ -339,85 +339,6 @@ test(`emitting dom api destroy`, t => {
 	})
 
 	stateRouter.go(`state`, {})
-})
-
-test(`emitting dom api reset`, t => {
-	const originalDomApi = {}
-	const secondDomApi = {}
-	const domApis = [ originalDomApi, secondDomApi ]
-	let beforeEventFired = false
-	let afterEventFired = false
-	let resetCalled = false
-
-	t.plan(16)
-
-	const state = getTestState(t, () => ({
-		render(context, cb) {
-			cb(null, domApis.shift())
-		},
-		reset(context, cb) {
-			if (!resetCalled) {
-				t.ok(beforeEventFired)
-				t.notOk(afterEventFired)
-				resetCalled = true
-			}
-
-			cb(null)
-		},
-		destroy(renderedTemplateApi, cb) {
-			cb(null)
-		},
-		getChildElement: function getChildElement(renderedTemplateApi, cb) {
-			cb(null, {})
-		},
-	}))
-	const stateRouter = state.stateRouter
-
-	const originalStateObject = {
-		name: `state`,
-		route: `/state`,
-		template: {},
-		querystringParameters: [ `wat` ],
-		resolve(data, params, cb) {
-			cb(null, {
-				value: `legit`,
-			})
-		},
-		activate() {
-			setTimeout(() => {
-				stateRouter.go(`state`, { wat: `20` })
-			}, 10)
-		},
-	}
-
-	stateRouter.addState(originalStateObject)
-
-	stateRouter.on(`beforeResetState`, context => {
-		t.notOk(beforeEventFired)
-		t.notOk(resetCalled)
-		t.notOk(afterEventFired)
-		beforeEventFired = true
-
-		t.equal(context.state, originalStateObject)
-		t.equal(context.domApi, originalDomApi)
-		t.equal(context.content.value, `legit`)
-		t.equal(context.parameters.wat, `20`)
-	})
-
-	stateRouter.on(`afterResetState`, context => {
-		t.ok(beforeEventFired)
-		t.ok(resetCalled)
-		t.notOk(afterEventFired)
-		afterEventFired = true
-
-		t.equal(context.state, originalStateObject)
-		t.equal(context.domApi, originalDomApi)
-		t.equal(context.content.value, `legit`)
-		t.equal(context.parameters.wat, `20`)
-		t.end()
-	})
-
-	stateRouter.go(`state`, { wat: `10` })
 })
 
 test(`emitting routeNotFound`, t => {

--- a/test/emitters.js
+++ b/test/emitters.js
@@ -215,8 +215,8 @@ test(`emitting dom api create`, t => {
 			t.notOk(afterEventFired)
 			cb(null, originalDomApi)
 		},
-		reset(context, cb) {
-			t.ok(false, `Reset should not be called`)
+		reset() {
+			t.fail(`Reset should not be called`)
 		},
 		destroy(renderedTemplateApi, cb) {
 			cb(null)

--- a/test/emitters.js
+++ b/test/emitters.js
@@ -283,8 +283,8 @@ test(`emitting dom api destroy`, t => {
 		render(context, cb) {
 			cb(null, originalDomApi)
 		},
-		reset(context, cb) {
-			t.ok(false, `Reset should not be called`)
+		reset() {
+			t.fail(`Reset should not be called`)
 		},
 		destroy(renderedTemplateApi, cb) {
 			t.ok(beforeEventFired)

--- a/test/helpers/asserting-renderer-factory.js
+++ b/test/helpers/asserting-renderer-factory.js
@@ -13,8 +13,8 @@ module.exports = function assertingRendererFactory(t, expectedTemplates) {
 					})
 				})
 			},
-			reset: function reset(context, cb) {
-				setTimeout(cb, 100)
+			reset: function reset() {
+				throw new Error(`Reset should not be called`)
 			},
 			destroy: function destroy(renderedTemplateApi, cb) {
 				setTimeout(cb, 100)

--- a/test/helpers/renderer-mock.js
+++ b/test/helpers/renderer-mock.js
@@ -1,44 +1,30 @@
-function myArbitraryRenderFunction(parent, cb) {
+async function myArbitraryRenderFunction(parent) {
 	const child = {}
 
 	const newObject = {
-		reset: function whatever() {},
 		getChildElement() {
 			return child
 		},
 		teardown() {
 			newObject.getChildElement = null
-			newObject.reset = null
 			newObject.teardown = null
 		},
 	}
 
-	setTimeout(() => {
-		cb(newObject)
-	}, 100)
+	return newObject
 }
 
 module.exports = function makeRenderer(stateRouter) {
 	return {
-		render: function render(context, cb) {
+		async render(context) {
 			const element = context.element
-			myArbitraryRenderFunction(element, renderedTemplateApi => {
-				cb(null, renderedTemplateApi)
-			})
+			return await myArbitraryRenderFunction(element)
 		},
-		reset: function reset(context, cb) {
-			const renderedTemplateApi = context.domApi
-			renderedTemplateApi.reset()
-			setTimeout(cb, 100)
+		async destroy(renderedTemplateApi) {
+			await renderedTemplateApi.teardown()
 		},
-		destroy: function destroy(renderedTemplateApi, cb) {
-			renderedTemplateApi.teardown()
-			setTimeout(cb, 100)
-		},
-		getChildElement: function getChildElement(renderedTemplateApi, cb) {
-			setTimeout(() => {
-				cb(null, renderedTemplateApi.getChildElement(`ui-view`))
-			}, 100)
+		async getChildElement(renderedTemplateApi) {
+			return await renderedTemplateApi.getChildElement(`ui-view`)
 		},
 	}
 }

--- a/test/interpreting-state-changes.js
+++ b/test/interpreting-state-changes.js
@@ -26,7 +26,6 @@ test(`State change logic`, t => {
 		nameAfter: `app.main.tab2`,
 	}], {
 		destroy: [ `app.main.tab1` ],
-		change: [],
 		create: [ `app.main.tab2` ],
 	})
 
@@ -47,7 +46,6 @@ test(`State change logic`, t => {
 		nameAfter: `app.main.tab1`,
 	}], {
 		destroy: [ `login` ],
-		change: [],
 		create: [ `app`, `app.main`, `app.main.tab1` ],
 	})
 
@@ -68,7 +66,6 @@ test(`State change logic`, t => {
 		nameAfter: undefined,
 	}], {
 		destroy: [ `app`, `app.main`, `app.main.tab2` ],
-		change: [],
 		create: [ `logout` ],
 	})
 
@@ -88,9 +85,8 @@ test(`State change logic`, t => {
 		nameBefore: `app.main.tab1`,
 		nameAfter: `app.main.tab1`,
 	}], {
-		destroy: [],
-		change: [ `app.main`, `app.main.tab1` ],
-		create: [],
+		destroy: [ `app.main`, `app.main.tab1` ],
+		create: [ `app.main`, `app.main.tab1` ],
 	})
 
 	check(`changing mid-level parameter and low-level name`, [{
@@ -109,9 +105,8 @@ test(`State change logic`, t => {
 		nameBefore: `app.main.tab1`,
 		nameAfter: `app.main.tab2`,
 	}], {
-		destroy: [ `app.main.tab1` ],
-		change: [ `app.main` ],
-		create: [ `app.main.tab2` ],
+		destroy: [ `app.main`, `app.main.tab1` ],
+		create: [ `app.main`, `app.main.tab2` ],
 	})
 
 	check(`changing highest-level parameter`, [{
@@ -130,9 +125,8 @@ test(`State change logic`, t => {
 		nameBefore: `app.main.tab1`,
 		nameAfter: `app.main.tab1`,
 	}], {
-		destroy: [],
-		change: [ `app`, `app.main`, `app.main.tab1` ],
-		create: [],
+		destroy: [ `app`, `app.main`, `app.main.tab1` ],
+		create: [ `app`, `app.main`, `app.main.tab1` ],
 	})
 
 	t.end()

--- a/test/test.js
+++ b/test/test.js
@@ -285,27 +285,6 @@ test(`render fn receives parameters`, t => {
 	stateRouter.go(`x`, { foo: `abc` })
 })
 
-test(`reset fn receives parameters`, t => {
-	t.plan(1)
-	const stateRouter = getTestState(t, () => ({
-		render(context, cb) {
-			cb()
-		},
-		reset(context) {
-			t.deepEqual(context.parameters, { foo: `def` })
-		},
-	})).stateRouter
-	stateRouter.addState({
-		name: `x`,
-		route: `/x/:foo`,
-		template: ``,
-	})
-	stateRouter.on(`stateChangeEnd`, () => {
-		stateRouter.go(`x`, { foo: `def` })
-	})
-	stateRouter.go(`x`, { foo: `abc` })
-})
-
 test(`go uses current state when no stateName is provided`, t => {
 	const testState = getTestState(t)
 	const stateRouter = testState.stateRouter


### PR DESCRIPTION
The concept of resetting breaks down if your component library doesn't support
- slots
- resetting the state of a component without resetting the contents of slots

For renderers that "reset" states by destroying the existing component and re-constructing it, stuff would break in any case where a parent and child state were both told to reset at once.  Whenever the parent would reset and destroy its part of the DOM, the child would get wiped out.

Existing renderers don't need to change to work with this version of ASR, it's just that their `reset` function won't get called any more.

The core change to the business logic is in `lib/state-change-logic.js`.