### PR TITLE
Don't mutate activeStateResolveContent before states are destroyed

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,7 @@
+# [7.3.1](https://github.com/TehShrike/abstract-state-router/releases/tag/v7.3.1)
+
+Fixes an issue where when a state was destroyed and resolved during the same state change, the result of its `resolve` function would get tossed out.
+
 # [7.3.0](https://github.com/TehShrike/abstract-state-router/releases/tag/v7.3.0)
 
 Removes the concept of resetting states.

--- a/index.js
+++ b/index.js
@@ -244,10 +244,11 @@ module.exports = function StateProvider(makeRenderer, rootElement, stateRouterOp
 						stateChanges.create,
 					)
 
-					activeStateResolveContent = extend(activeStateResolveContent, stateResolveResultsObject)
-
 					return series(reverse(stateChanges.destroy), destroyStateName).then(
-						() => renderAll(stateChanges.create, extend(parameters)).then(activateAll),
+						() => {
+							activeStateResolveContent = extend(activeStateResolveContent, stateResolveResultsObject)
+							return renderAll(stateChanges.create, extend(parameters)).then(activateAll)
+						},
 					)
 				}))
 

--- a/test/destroy.js
+++ b/test/destroy.js
@@ -152,3 +152,37 @@ test(`a state with changing querystring gets destroyed`, t => {
 
 	stateRouter.go(`parent.child1`)
 })
+
+test(`When navigating to the same state as before, make sure the data from the child's resolve gets passed along`, t => {
+	const state = getTestState(t)
+	const stateRouter = state.stateRouter
+
+	let activations = 0
+
+	t.plan(2)
+
+	stateRouter.addState({
+		name: `parent`,
+		route: `/parent`,
+		template: null,
+		querystringParameters: [ `aParam` ],
+		async resolve() {
+			return {
+				legit: true,
+			}
+		},
+		activate({ content }) {
+			activations++
+
+			t.equal(content.legit, true)
+
+			if (activations === 2) {
+				t.end()
+			} else {
+				stateRouter.go(`parent`, { aParam: `something different` })
+			}
+		},
+	})
+
+	stateRouter.go(`parent`)
+})


### PR DESCRIPTION
This bug was introduced in the change where state resets went away – when states are destroyed, their resolve data on the global activeStateResolveContent object would get wiped.

Now that resets have been converted into destroys+creates, this one line that tosses the data from the resolve functions onto activeStateResolveContent is obviously in the wrong place... it happens right before the states get destroyed.

If any of the states that were destroyed are also being created, the data returned by the resolve functions for the created states would get ignored.