### PR TITLE
Support passing an `allowStateChange` function that is evaluated befo…

### DIFF
--- a/index.js
+++ b/index.js
@@ -149,7 +149,11 @@ module.exports = function StateProvider(makeRenderer, rootElement, stateRouterOp
 			const allowStateChange = statesNamesToCheck.every(stateName => {
 				const state = prototypalStateHolder.get(stateName)
 				if (state?.allowStateChange && typeof state.allowStateChange === 'function') {
-					return state.allowStateChange(activeDomApis[stateName])
+					const stateChangeAllowed = state.allowStateChange(activeDomApis[stateName])
+					if (!stateChangeAllowed) {
+						stateProviderEmitter.emit('stateChangePrevented', stateName)
+					}
+					return stateChangeAllowed
 				}
 				return true
 			})

--- a/index.js
+++ b/index.js
@@ -167,15 +167,12 @@ module.exports = function StateProvider(makeRenderer, rootElement, stateRouterOp
 	}
 
 	function onRouteChange(state, parameters) {
-		if (!allowStateChangeOrRevert(state, parameters)) {
-			return
-		}
 		try {
 			const finalDestinationStateName = prototypalStateHolder.applyDefaultChildStates(state.name)
 
-			if (finalDestinationStateName === state.name) {
+			if (finalDestinationStateName === state.name && allowStateChangeOrRevert(state, parameters)) {
 				emitEventAndAttemptStateChange(finalDestinationStateName, parameters)
-			} else {
+			} else if (finalDestinationStateName !== state.name) {
 				// There are default child states that need to be applied
 
 				const theRouteWeNeedToEndUpAt = makePath(finalDestinationStateName, parameters)

--- a/index.js
+++ b/index.js
@@ -133,8 +133,8 @@ module.exports = function StateProvider(makeRenderer, rootElement, stateRouterOp
 	}
 
 	function allowStateChangeOrRevert(newState, newParameters) {
-		const lastState = stateProviderEmitter.getActiveState()
-		if (lastState.name) {
+		const lastState = lastCompletelyLoadedState.get()
+		if (lastState.name && lastState.name === lastStateStartedActivating.get().name) {
 			// Check allowStateChange for all states that will be destroyed or changed
 			const { change, destroy } = stateChangeLogic(
 				compareStartAndEndStates({

--- a/index.js
+++ b/index.js
@@ -145,7 +145,7 @@ module.exports = function StateProvider(makeRenderer, rootElement, stateRouterOp
 					},
 				}),
 			)
-			const statesNamesToCheck = change.concat(destroy)
+			const statesNamesToCheck = change?.concat(destroy) ?? destroy ?? []
 			const allowStateChange = statesNamesToCheck.every(stateName => {
 				const state = prototypalStateHolder.get(stateName)
 				if (state?.allowStateChange && typeof state.allowStateChange === 'function') {

--- a/index.js
+++ b/index.js
@@ -149,7 +149,7 @@ module.exports = function StateProvider(makeRenderer, rootElement, stateRouterOp
 			const allowStateChange = statesNamesToCheck.every(stateName => {
 				const state = prototypalStateHolder.get(stateName)
 				if (state?.allowStateChange && typeof state.allowStateChange === 'function') {
-					return state.allowStateChange(newState, newParameters, activeDomApis[stateName])
+					return state.allowStateChange(activeDomApis[stateName])
 				}
 				return true
 			})

--- a/index.js
+++ b/index.js
@@ -376,7 +376,7 @@ module.exports = function StateProvider(makeRenderer, rootElement, stateRouterOp
 		const parametersWereNotPassedIn = !parameters
 
 		return stateNameMatches
-			&& (parametersWereNotPassedIn || Object.keys(parameters).every(key => `${parameters[key] }` === currentState.parameters[key]))
+			&& (parametersWereNotPassedIn || Object.keys(parameters).every(key => `${ parameters[key] }` === currentState.parameters[key]))
 	}
 
 	const renderer = makeRenderer(stateProviderEmitter)

--- a/readme.md
+++ b/readme.md
@@ -115,6 +115,8 @@ If the viewer navigates to a state that has a default child, the router will red
 
 For backwards compatibility reasons, `defaultQuerystringParameters` will work as well (though it does not function any differently).
 
+`allowStateChange` is an optional function with the state's domApi as its sole argument. If it returns `false`, navigation from the state will be prevented. If it is returns `true` or is left `undefined`, state changes will not be prevented.
+
 ### resolve(data, parameters, callback(err, content).redirect(stateName, [stateParameters]))
 
 `data` is the data object you passed to the addState call.  `parameters` is an object containing the parameters that were parsed out of the route and the query string.

--- a/readme.md
+++ b/readme.md
@@ -55,19 +55,19 @@ Want to use the abstract-state-router without messing with bundlers or package m
 # API
 
 - [Instantiate](#instantiate)
-	- [`options`](#options)
+  - [`options`](#options)
 - [`addState`](#staterouteraddstatename-route-defaultchild-data-template-resolve-activate-querystringparameters-defaultparameters)
-	- [`resolve`](#resolvedata-parameters-callbackerr-contentredirectstatename-stateparameters)
-	- [`activate`](#activatecontext)
-	- [Examples](#addstate-examples)
+  - [`resolve`](#resolvedata-parameters-callbackerr-contentredirectstatename-stateparameters)
+  - [`activate`](#activatecontext)
+  - [Examples](#addstate-examples)
 - [`go`](#stateroutergostatename-stateparameters-options)
 - [`evaluateCurrentRoute`](#staterouterevaluatecurrentroutefallbackstatename-fallbackstateparameters)
 - [`stateIsActive`](#staterouterstateisactivestatename-stateparameters)
 - [`makePath`](#stateroutermakepathstatename-stateparameters-options)
 - [`getActiveState`](#stateroutergetactivestate)
 - [Events](#events)
-	- [State change](#state-change)
-	- [DOM API interactions](#dom-api-interactions)
+  - [State change](#state-change)
+  - [DOM API interactions](#dom-api-interactions)
 
 ## Instantiate
 
@@ -115,7 +115,7 @@ If the viewer navigates to a state that has a default child, the router will red
 
 For backwards compatibility reasons, `defaultQuerystringParameters` will work as well (though it does not function any differently).
 
-`allowStateChange` is an optional function with the state's domApi as its sole argument. If it returns `false`, navigation from the state will be prevented. If it is returns `true` or is left `undefined`, state changes will not be prevented.
+`canLeaveState` is an optional function with the state's domApi as its sole argument. If it returns `false`, navigation from the state will be prevented. If it is returns `true` or is left `undefined`, state changes will not be prevented.
 
 ### resolve(data, parameters, callback(err, content).redirect(stateName, [stateParameters]))
 

--- a/test/allow-state-change.js
+++ b/test/allow-state-change.js
@@ -159,9 +159,7 @@ test(`allowStateChange can access domApi`, t => {
 				return true
 			},
 			resolve() {
-				return Promise.resolve({
-					foo: `bar`,
-				})
+				return Promise.resolve()
 			},
 			activate(context) {
 				//
@@ -200,6 +198,91 @@ test(`allowStateChange can access domApi`, t => {
 				t.end()
 			}
 		})
+	})
+
+	// TODO: I'm not sure how to write a test for the hashRouter
+})
+
+test(`allowStateChange will only fire once when getting redirected to a child`, t => {
+	function startTest(t) {
+		const state = getTestState(t)
+		const stateRouter = state.stateRouter
+		let allowStateChangeCalls = 0
+		t.plan(1)
+
+		stateRouter.addState({
+			name: `start`,
+			route: `/start`,
+			template: {},
+			allowStateChange: () => {
+				t.ok(allowStateChangeCalls === 0, `allowStateChange called`)
+				allowStateChangeCalls++
+				return true
+			},
+			resolve() {
+				return Promise.resolve()
+			},
+			activate(context) {
+			},
+		})
+
+		stateRouter.addState({
+			name: `end`,
+			route: `/end`,
+			defaultChild: `child`,
+			template: {},
+			resolve() {
+				return Promise.resolve()
+			},
+			activate() {
+			},
+		})
+
+		stateRouter.addState({
+			name: `end.child`,
+			route: `/child`,
+			template: {},
+			resolve() {
+				return Promise.resolve()
+			},
+			activate() {
+				t.end()
+			},
+		})
+
+		return state
+	}
+
+	t.test(`with state.go and applying default child`, t => {
+		const stateRouter = startTest(t).stateRouter
+		let arrivedAtStart = false
+
+		stateRouter.on(`stateChangeEnd`, () => {
+			const stateName = stateRouter.getActiveState().name
+
+			if (stateName === 'start' && !arrivedAtStart) {
+				arrivedAtStart = true
+				stateRouter.go(`end`)
+			}
+		})
+
+		stateRouter.go(`start`)
+	})
+
+	t.test(`with state.go and going directly to child`, t => {
+		const stateRouter = startTest(t).stateRouter
+		let arrivedAtStart = false
+
+		stateRouter.on(`stateChangeEnd`, () => {
+			const stateName = stateRouter.getActiveState().name
+
+			if (stateName === 'start' && !arrivedAtStart) {
+				arrivedAtStart = true
+				stateRouter.go(`end.child`)
+			}
+		})
+
+		stateRouter.go(`start`)
 	})
 
 	// TODO: I'm not sure how to write a test for the hashRouter

--- a/test/allow-state-change.js
+++ b/test/allow-state-change.js
@@ -1,7 +1,7 @@
 const test = require(`tape-catch`)
 const getTestState = require(`./helpers/test-state-factory`)
 
-test(`allowStateChange false prevents state change`, t => {
+test(`canLeaveState false prevents state change`, t => {
 	function startTest(t) {
 		const state = getTestState(t)
 		const stateRouter = state.stateRouter
@@ -11,8 +11,8 @@ test(`allowStateChange false prevents state change`, t => {
 			name: `guarded`,
 			route: `/guarded`,
 			template: {},
-			allowStateChange: () => {
-				t.ok(true, `allowStateChange called`)
+			canLeaveState: () => {
+				t.ok(true, `canLeaveState called`)
 				return false
 			},
 			resolve() {
@@ -109,7 +109,7 @@ test(`allowStateChange false prevents state change`, t => {
 	t.end()
 })
 
-test(`allowStateChange true lets the state change`, t => {
+test(`canLeaveState true lets the state change`, t => {
 	function startTest(t) {
 		const state = getTestState(t)
 		const stateRouter = state.stateRouter
@@ -119,8 +119,8 @@ test(`allowStateChange true lets the state change`, t => {
 			name: `start`,
 			route: `/start`,
 			template: {},
-			allowStateChange: () => {
-				t.ok(true, `allowStateChange called`)
+			canLeaveState: () => {
+				t.ok(true, `canLeaveState called`)
 				return true
 			},
 			resolve() {
@@ -199,7 +199,7 @@ test(`allowStateChange true lets the state change`, t => {
 	})
 })
 
-test(`allowStateChange can access domApi`, t => {
+test(`canLeaveState can access domApi`, t => {
 	function startTest(t) {
 		const state = getTestState(t)
 		const stateRouter = state.stateRouter
@@ -209,8 +209,8 @@ test(`allowStateChange can access domApi`, t => {
 			name: `start`,
 			route: `/start`,
 			template: {},
-			allowStateChange: domApi => {
-				t.ok(true, `allowStateChange called`)
+			canLeaveState: domApi => {
+				t.ok(true, `canLeaveState called`)
 				if (domApi.teardown && domApi.getChildElement) {
 					t.pass(`can access domApi`)
 				}
@@ -259,20 +259,20 @@ test(`allowStateChange can access domApi`, t => {
 	})
 })
 
-test(`allowStateChange will only fire once`, t => {
+test(`canLeaveState will only fire once`, t => {
 	function startTest(t) {
 		const state = getTestState(t)
 		const stateRouter = state.stateRouter
-		let allowStateChangeCalls = 0
+		let canLeaveStateCalls = 0
 		t.plan(1)
 
 		stateRouter.addState({
 			name: `start`,
 			route: `/start`,
 			template: {},
-			allowStateChange: () => {
-				t.ok(allowStateChangeCalls === 0, `allowStateChange called`)
-				allowStateChangeCalls++
+			canLeaveState: () => {
+				t.ok(canLeaveStateCalls === 0, `canLeaveState called`)
+				canLeaveStateCalls++
 				return true
 			},
 			resolve() {
@@ -373,7 +373,7 @@ test(`allowStateChange will only fire once`, t => {
 		stateRouter.go(`start`)
 	})
 
-	t.test(`Getting redirected with parameters`, t => {
+	t.test(`Getting redirected to self with different parameters`, t => {
 		const stateRouter = startTest(t).stateRouter
 		let arrivedAtStart = false
 

--- a/test/allow-state-change.js
+++ b/test/allow-state-change.js
@@ -72,7 +72,39 @@ test(`allowStateChange false prevents state change`, t => {
 		})
 	})
 
-	// TODO: I'm not sure how to write a test for the hashRouter
+	t.test(`by changing the URL`, t => {
+		const testState = startTest(t)
+		const stateRouter = testState.stateRouter
+		const hashRouter = testState.hashRouter
+
+		hashRouter.go(`/guarded`)
+
+		let arrivedAtStart = false
+
+		stateRouter.on('stateChangeStart', state => {
+			if (state.name === 'unreachable') {
+				t.fail(`state change should not start ${ state.name }`)
+			}
+		})
+
+		stateRouter.on('stateChangeEnd', state => {
+			const stateName = state.name
+
+			if (stateName === 'guarded' && !arrivedAtStart) {
+				arrivedAtStart = true
+				hashRouter.go(`/unreachable`)
+			}
+		})
+
+		stateRouter.on('stateChangePrevented', stateThatPreventedChange => {
+			if (stateThatPreventedChange === 'guarded') {
+				t.pass(`state change was prevented`)
+			} else {
+				t.fail(`state change was prevented by the wrong state`)
+			}
+			t.end()
+		})
+	})
 
 	t.end()
 })
@@ -138,7 +170,33 @@ test(`allowStateChange true lets the state change`, t => {
 		})
 	})
 
-	// TODO: I'm not sure how to write a test for the hashRouter
+	t.test(`by changing the URL`, t => {
+		const testState = startTest(t)
+		const stateRouter = testState.stateRouter
+		const hashRouter = testState.hashRouter
+
+		hashRouter.go(`/start`)
+
+		let arrivedAtStart = false
+
+		stateRouter.on(`stateChangeEnd`, state => {
+			const stateName = state.name
+
+			if (stateName === 'start' && !arrivedAtStart) {
+				arrivedAtStart = true
+				hashRouter.go(`/end`)
+			}
+
+			if (stateName === 'end') {
+				t.pass(`state change was allowed`)
+				t.end()
+			}
+		})
+
+		stateRouter.on('stateChangePrevented', stateThatPreventedChange => {
+			t.fail(`state change was prevented by ${ stateThatPreventedChange }`)
+		})
+	})
 })
 
 test(`allowStateChange can access domApi`, t => {
@@ -199,8 +257,6 @@ test(`allowStateChange can access domApi`, t => {
 			}
 		})
 	})
-
-	// TODO: I'm not sure how to write a test for the hashRouter
 })
 
 test(`allowStateChange will only fire once when getting redirected to a child`, t => {
@@ -284,6 +340,4 @@ test(`allowStateChange will only fire once when getting redirected to a child`, 
 
 		stateRouter.go(`start`)
 	})
-
-	// TODO: I'm not sure how to write a test for the hashRouter
 })

--- a/test/allow-state-change.js
+++ b/test/allow-state-change.js
@@ -1,0 +1,206 @@
+const test = require(`tape-catch`)
+const getTestState = require(`./helpers/test-state-factory`)
+
+test(`allowStateChange false prevents state change`, t => {
+	function startTest(t) {
+		const state = getTestState(t)
+		const stateRouter = state.stateRouter
+		t.plan(2)
+
+		stateRouter.addState({
+			name: `guarded`,
+			route: `/guarded`,
+			template: {},
+			allowStateChange: () => {
+				t.ok(true, `allowStateChange called`)
+				return false
+			},
+			resolve() {
+				return Promise.resolve()
+			},
+			activate(context) {
+				context.on(`destroy`, () => {
+					t.pass(`should not destroy guarded state`)
+				})
+			},
+		})
+
+		stateRouter.addState({
+			name: `unreachable`,
+			route: `/unreachable`,
+			template: {},
+			resolve() {
+				t.fail(`Should not resolve`)
+				return Promise.resolve()
+			},
+			activate() {
+				// will not get called
+			},
+		})
+
+		return state
+	}
+
+	t.test(`with state.go`, t => {
+		const stateRouter = startTest(t).stateRouter
+		let arrivedAtStart = false
+
+		stateRouter.go(`guarded`)
+
+		stateRouter.on('stateChangeStart', state => {
+			if (state.name === 'unreachable') {
+				t.fail(`state change should not start ${ state.name }`)
+			}
+		})
+
+		stateRouter.on('stateChangeEnd', state => {
+			const stateName = state.name
+
+			if (stateName === 'guarded' && !arrivedAtStart) {
+				arrivedAtStart = true
+				stateRouter.go(`unreachable`)
+			}
+		})
+
+		stateRouter.on('stateChangePrevented', stateThatPreventedChange => {
+			if (stateThatPreventedChange === 'guarded') {
+				t.pass(`state change was prevented`)
+			} else {
+				t.fail(`state change was prevented by the wrong state`)
+			}
+			t.end()
+		})
+	})
+
+	// TODO: I'm not sure how to write a test for the hashRouter
+
+	t.end()
+})
+
+test(`allowStateChange true lets the state change`, t => {
+	function startTest(t) {
+		const state = getTestState(t)
+		const stateRouter = state.stateRouter
+		t.plan(2)
+
+		stateRouter.addState({
+			name: `start`,
+			route: `/start`,
+			template: {},
+			allowStateChange: () => {
+				t.ok(true, `allowStateChange called`)
+				return true
+			},
+			resolve() {
+				return Promise.resolve()
+			},
+			activate(context) {
+				//
+			},
+		})
+
+		stateRouter.addState({
+			name: `end`,
+			route: `/end`,
+			template: {},
+			resolve() {
+				return Promise.resolve()
+			},
+			activate() {
+			},
+		})
+
+		return state
+	}
+
+	t.test(`with state.go`, t => {
+		const stateRouter = startTest(t).stateRouter
+		let arrivedAtStart = false
+
+		stateRouter.go(`start`)
+
+		stateRouter.on(`stateChangeEnd`, state => {
+			const stateName = state.name
+
+			if (stateName === 'start' && !arrivedAtStart) {
+				arrivedAtStart = true
+				stateRouter.go(`end`)
+			}
+
+			if (stateName === 'end') {
+				t.pass(`state change was allowed`)
+				t.end()
+			}
+		})
+
+		stateRouter.on('stateChangePrevented', stateThatPreventedChange => {
+			t.fail(`state change was prevented by ${ stateThatPreventedChange }`)
+		})
+	})
+
+	// TODO: I'm not sure how to write a test for the hashRouter
+})
+
+test(`allowStateChange can access domApi`, t => {
+	function startTest(t) {
+		const state = getTestState(t)
+		const stateRouter = state.stateRouter
+		t.plan(2)
+
+		stateRouter.addState({
+			name: `start`,
+			route: `/start`,
+			template: {},
+			allowStateChange: domApi => {
+				t.ok(true, `allowStateChange called`)
+				if (domApi.teardown && domApi.getChildElement) {
+					t.pass(`can access domApi`)
+				}
+				return true
+			},
+			resolve() {
+				return Promise.resolve({
+					foo: `bar`,
+				})
+			},
+			activate(context) {
+				//
+			},
+		})
+
+		stateRouter.addState({
+			name: `end`,
+			route: `/end`,
+			template: {},
+			resolve() {
+				return Promise.resolve()
+			},
+			activate() {
+			},
+		})
+
+		return state
+	}
+
+	t.test(`with state.go`, t => {
+		const stateRouter = startTest(t).stateRouter
+		let arrivedAtStart = false
+
+		stateRouter.go(`start`)
+
+		stateRouter.on(`stateChangeEnd`, () => {
+			const stateName = stateRouter.getActiveState().name
+
+			if (stateName === 'start' && !arrivedAtStart) {
+				arrivedAtStart = true
+				stateRouter.go(`end`)
+			}
+
+			if (stateName === 'end') {
+				t.end()
+			}
+		})
+	})
+
+	// TODO: I'm not sure how to write a test for the hashRouter
+})


### PR DESCRIPTION
…re a state change

The URL will have already changed at this point, but since `allowStateChange` is evaluated before the state change has started, we can just set the URL back to what it was before without reloading any states.