### PR TITLE
Don't check a state's `canLeaveState` function twice if it's destroyed and created

### DIFF
--- a/index.js
+++ b/index.js
@@ -156,7 +156,7 @@ module.exports = function StateProvider(makeRenderer, rootElement, stateRouterOp
 					},
 				}),
 			)
-			const statesNamesToCheck = [ ...create, ...destroy ]
+			const statesNamesToCheck = Array.from(new Set([ ...create, ...destroy ]).values())
 			const canLeaveState = statesNamesToCheck.every(stateName => {
 				const state = prototypalStateHolder.get(stateName)
 				if (state?.canLeaveState && typeof state.canLeaveState === 'function') {


### PR DESCRIPTION
If you reload the same state, it is in both the create and destroy arrays, so you have to make sure it only gets checked once.