### PR TITLE
Fix `canLeaveState` being called on initial state load

### DIFF
--- a/index.js
+++ b/index.js
@@ -159,7 +159,7 @@ module.exports = function StateProvider(makeRenderer, rootElement, stateRouterOp
 			const statesNamesToCheck = Array.from(new Set([ ...create, ...destroy ]).values())
 			const canLeaveState = statesNamesToCheck.every(stateName => {
 				const state = prototypalStateHolder.get(stateName)
-				if (state?.canLeaveState && typeof state.canLeaveState === 'function') {
+				if (state?.canLeaveState && typeof state.canLeaveState === 'function' && activeDomApis[stateName]) {
 					const stateChangeAllowed = state.canLeaveState(activeDomApis[stateName])
 					if (!stateChangeAllowed) {
 						stateProviderEmitter.emit('stateChangePrevented', stateName)


### PR DESCRIPTION
We want it to call `canLeaveState` when we reload a state, but not when we load it for the first time.