### PR TITLE
Pass destination state name and parameters to `canLeaveState` and `stateChangePrevented`

### DIFF
--- a/index.js
+++ b/index.js
@@ -158,9 +158,15 @@ module.exports = function StateProvider(makeRenderer, rootElement, stateRouterOp
 			const canLeaveStates = destroy.every(stateName => {
 				const state = prototypalStateHolder.get(stateName)
 				if (state.canLeaveState && typeof state.canLeaveState === 'function') {
-					const stateChangeAllowed = state.canLeaveState(activeDomApis[stateName])
+					const stateChangeAllowed = state.canLeaveState(activeDomApis[stateName], {
+						name: newStateName,
+						parameters: newParameters,
+					})
 					if (!stateChangeAllowed) {
-						stateProviderEmitter.emit('stateChangePrevented', stateName)
+						stateProviderEmitter.emit('stateChangePrevented', stateName, {
+							name: newStateName,
+							parameters: newParameters,
+						})
 					}
 					return stateChangeAllowed
 				}

--- a/index.js
+++ b/index.js
@@ -163,7 +163,10 @@ module.exports = function StateProvider(makeRenderer, rootElement, stateRouterOp
 						parameters: newParameters,
 					})
 					if (!stateChangeAllowed) {
-						stateProviderEmitter.emit('stateChangePrevented', stateName, {
+						stateProviderEmitter.emit('stateChangePrevented', {
+							name: stateName,
+							parameters: lastState.parameters,
+						}, {
 							name: newStateName,
 							parameters: newParameters,
 						})

--- a/test/allow-state-change.js
+++ b/test/allow-state-change.js
@@ -63,7 +63,7 @@ test(`canLeaveState false prevents state change`, t => {
 		})
 
 		stateRouter.on('stateChangePrevented', stateThatPreventedChange => {
-			if (stateThatPreventedChange === 'guarded') {
+			if (stateThatPreventedChange.name === 'guarded') {
 				t.pass(`state change was prevented`)
 			} else {
 				t.fail(`state change was prevented by the wrong state`)
@@ -97,7 +97,7 @@ test(`canLeaveState false prevents state change`, t => {
 		})
 
 		stateRouter.on('stateChangePrevented', stateThatPreventedChange => {
-			if (stateThatPreventedChange === 'guarded') {
+			if (stateThatPreventedChange.name === 'guarded') {
 				t.pass(`state change was prevented`)
 			} else {
 				t.fail(`state change was prevented by the wrong state`)
@@ -166,7 +166,7 @@ test(`canLeaveState true lets the state change`, t => {
 		})
 
 		stateRouter.on('stateChangePrevented', stateThatPreventedChange => {
-			t.fail(`state change was prevented by ${ stateThatPreventedChange }`)
+			t.fail(`state change was prevented by ${ stateThatPreventedChange.name }`)
 		})
 	})
 
@@ -194,7 +194,7 @@ test(`canLeaveState true lets the state change`, t => {
 		})
 
 		stateRouter.on('stateChangePrevented', stateThatPreventedChange => {
-			t.fail(`state change was prevented by ${ stateThatPreventedChange }`)
+			t.fail(`state change was prevented by ${ stateThatPreventedChange.name }`)
 		})
 	})
 })
@@ -524,7 +524,7 @@ test(`canLeaveState will not fire on state load`, t => {
 	})
 
 	stateRouter.on('stateChangePrevented', stateThatPreventedChange => {
-		t.fail(`state change was prevented by ${ stateThatPreventedChange }`)
+		t.fail(`state change was prevented by ${ stateThatPreventedChange.name }`)
 	})
 
 	stateRouter.go(`start`, { foo: `bar` })
@@ -556,8 +556,8 @@ test('canLeaveState passes destination parameters', t => {
 
 	const stateRouter = startTest(t).stateRouter
 
-	stateRouter.on('stateChangePrevented', (stateThatPreventedChange, destinationState) => {
-		t.fail(`state change was prevented by ${ stateThatPreventedChange }`)
+	stateRouter.on('stateChangePrevented', stateThatPreventedChange => {
+		t.fail(`state change was prevented by ${ stateThatPreventedChange.name }`)
 	})
 
 	stateRouter.on('stateChangeEnd', (state, parameters) => {
@@ -569,11 +569,11 @@ test('canLeaveState passes destination parameters', t => {
 	stateRouter.go(`start`)
 })
 
-test('stateChangePrevented passes destination parameters', t => {
+test('stateChangePrevented passes source and destination parameters', t => {
 	function startTest(t) {
 		const state = getTestState(t)
 		const stateRouter = state.stateRouter
-		t.plan(2)
+		t.plan(4)
 
 		stateRouter.addState({
 			name: `start`,
@@ -593,7 +593,9 @@ test('stateChangePrevented passes destination parameters', t => {
 
 	const stateRouter = startTest(t).stateRouter
 
-	stateRouter.on('stateChangePrevented', (_stateThatPreventedChange, destinationState) => {
+	stateRouter.on('stateChangePrevented', (stateThatPreventedChange, destinationState) => {
+		t.ok(stateThatPreventedChange.name === 'start', 'source state is passed')
+		t.ok(stateThatPreventedChange.parameters.foo === 'baz', 'source parameters are passed')
 		t.ok(destinationState.name === 'start', 'destination state is passed')
 		t.ok(destinationState.parameters.foo === 'bar', 'destination parameters are passed')
 		t.end()
@@ -607,5 +609,5 @@ test('stateChangePrevented passes destination parameters', t => {
 		}
 	})
 
-	stateRouter.go(`start`)
+	stateRouter.go(`start`, { foo: 'baz' })
 })

--- a/test/allow-state-change.js
+++ b/test/allow-state-change.js
@@ -474,3 +474,138 @@ test(`canLeaveState will only fire once`, t => {
 		stateRouter.go(`start.child`)
 	})
 })
+
+test(`canLeaveState will not fire on state load`, t => {
+	function startTest(t) {
+		const state = getTestState(t)
+		const stateRouter = state.stateRouter
+		t.plan(1)
+
+		stateRouter.addState({
+			name: `start`,
+			route: `/start`,
+			querystringParameters: [ `foo` ],
+			template: {},
+			resolve() {
+				return Promise.resolve()
+			},
+		})
+
+		stateRouter.addState({
+			name: `end`,
+			route: `/end`,
+			template: {},
+			canLeaveState: () => {
+				t.fail(`canLeaveState should not be called`)
+				return false
+			},
+			resolve() {
+				return Promise.resolve()
+			},
+		})
+
+		return state
+	}
+
+	const stateRouter = startTest(t).stateRouter
+	let started = false
+
+	stateRouter.on(`stateChangeEnd`, state => {
+		const stateName = state.name
+		if (stateName === 'start') {
+			if (!started) {
+				started = true
+				stateRouter.go(`end`)
+			}
+		} else if (stateName === 'end') {
+			t.pass('state change was allowed')
+			t.end()
+		}
+	})
+
+	stateRouter.on('stateChangePrevented', stateThatPreventedChange => {
+		t.fail(`state change was prevented by ${ stateThatPreventedChange }`)
+	})
+
+	stateRouter.go(`start`, { foo: `bar` })
+})
+
+test('canLeaveState passes destination parameters', t => {
+	function startTest(t) {
+		const state = getTestState(t)
+		const stateRouter = state.stateRouter
+		t.plan(2)
+
+		stateRouter.addState({
+			name: `start`,
+			route: `/start`,
+			querystringParameters: [ `foo` ],
+			template: {},
+			canLeaveState: (_domApi, destinationState) => {
+				t.ok(destinationState.parameters.foo === 'bar', 'destination parameters are passed')
+				t.ok(destinationState.name === 'start', 'destination state is passed')
+				return true
+			},
+			resolve() {
+				return Promise.resolve()
+			},
+		})
+
+		return state
+	}
+
+	const stateRouter = startTest(t).stateRouter
+
+	stateRouter.on('stateChangePrevented', (stateThatPreventedChange, destinationState) => {
+		t.fail(`state change was prevented by ${ stateThatPreventedChange }`)
+	})
+
+	stateRouter.on('stateChangeEnd', (state, parameters) => {
+		if (state.name === 'start' && !parameters.foo) {
+			stateRouter.go(null, { foo: 'bar' })
+		}
+	})
+
+	stateRouter.go(`start`)
+})
+
+test('stateChangePrevented passes destination parameters', t => {
+	function startTest(t) {
+		const state = getTestState(t)
+		const stateRouter = state.stateRouter
+		t.plan(2)
+
+		stateRouter.addState({
+			name: `start`,
+			route: `/start`,
+			querystringParameters: [ `foo` ],
+			template: {},
+			canLeaveState: () => {
+				return false
+			},
+			resolve() {
+				return Promise.resolve()
+			},
+		})
+
+		return state
+	}
+
+	const stateRouter = startTest(t).stateRouter
+
+	stateRouter.on('stateChangePrevented', (_stateThatPreventedChange, destinationState) => {
+		t.ok(destinationState.name === 'start', 'destination state is passed')
+		t.ok(destinationState.parameters.foo === 'bar', 'destination parameters are passed')
+		t.end()
+	})
+
+	let started = false
+	stateRouter.on('stateChangeEnd', () => {
+		if (!started) {
+			started = true
+			stateRouter.go(null, { foo: 'bar' })
+		}
+	})
+
+	stateRouter.go(`start`)
+})


### PR DESCRIPTION
This will allow us to stop a state change in `canLeaveState`, and then re-initiate a state change to the same destination state afterwards.