### PR TITLE
Remove `defaultQuerystringParameters`

### DIFF
--- a/index.js
+++ b/index.js
@@ -19,7 +19,7 @@ const getProperty = name => obj => obj[name]
 const reverse = ary => ary.slice().reverse()
 const isFunction = property => obj => typeof obj[property] === `function`
 
-const expectedPropertiesOfAddState = [ `name`, `route`, `defaultChild`, `data`, `template`, `resolve`, `activate`, `querystringParameters`, `defaultQuerystringParameters`, `defaultParameters`, `canLeaveState` ]
+const expectedPropertiesOfAddState = [ `name`, `route`, `defaultChild`, `data`, `template`, `resolve`, `activate`, `querystringParameters`, `defaultParameters`, `canLeaveState` ]
 
 export default function StateProvider(makeRenderer, rootElement, stateRouterOptions = {}) {
 	const prototypalStateHolder = StateState()
@@ -261,7 +261,7 @@ export default function StateProvider(makeRenderer, rootElement, stateRouterOpti
 			await prototypalStateHolder.guaranteeAllStatesExist(newStateName)
 
 			const state = prototypalStateHolder.get(newStateName)
-			const defaultParams = state.defaultParameters || state.defaultQuerystringParameters || {}
+			const defaultParams = state.defaultParameters || {}
 			const needToApplyDefaults = Object.keys(defaultParams).some(param => typeof parameters[param] === 'undefined')
 
 			if (needToApplyDefaults) {
@@ -366,7 +366,7 @@ export default function StateProvider(makeRenderer, rootElement, stateRouterOpti
 		const destinationStateName = stateName === null ? getGuaranteedPreviousState().name : stateName
 
 		const destinationState = prototypalStateHolder.get(destinationStateName) || {}
-		const defaultParams = destinationState.defaultParameters || destinationState.defaultQuerystringParameters || {}
+		const defaultParams = destinationState.defaultParameters || {}
 
 		parameters = { ...computeDefaultParams(defaultParams), ...parameters }
 

--- a/readme.md
+++ b/readme.md
@@ -95,8 +95,6 @@ If the viewer navigates to a state that has a default child, the router will red
 
 `defaultParameters` is an object whose properties should correspond to parameters defined in the `querystringParameters` option or the route parameters.  Whatever values you supply here will be used as the defaults in case the url does not contain any value for that parameter. If you pass a function for a default parameter, the return of that function will be used as the default value.
 
-For backwards compatibility reasons, `defaultQuerystringParameters` will work as well (though it does not function any differently).
-
 `canLeaveState` is an optional function that takes two arguments: the state's domApi, and an object with the `name` and `parameters` of the state that the user is attempting to navigate to.  It can return either a boolean, or a promise that resolves to a boolean.  If `canLeaveState` returns `false`, navigation from the current state will be prevented. If the function returns `true` the state change will continue.
 
 ### resolve(data, parameters)

--- a/test/default-params.js
+++ b/test/default-params.js
@@ -32,30 +32,28 @@ test(`default querystring parameters`, async t => {
 		})
 	}
 
-	async function testWithBothPropertyNames(testName, params, expectParams, expectLocation) {
-		await basicTest(testName, params, expectParams, expectLocation, `defaultQuerystringParameters`)
-		await basicTest(testName, params, expectParams, expectLocation, `defaultParameters`)
-	}
-
-	await testWithBothPropertyNames(
+	await basicTest(
 		`params override defaults`,
 		{ wat: `waycool`, much: `awesome`, hi: `world` },
 		{ wat: `waycool`, much: `awesome`, hi: `world` },
 		`/state?hi=world&much=awesome&wat=waycool`,
+		'defaultParameters',
 	)
 
-	await testWithBothPropertyNames(
+	await basicTest(
 		`defaults and params are applied`,
 		{ wat: `roflol` },
 		{ wat: `roflol`, much: `neat` },
 		`/state?much=neat&wat=roflol`,
+		'defaultParameters',
 	)
 
-	await testWithBothPropertyNames(
+	await basicTest(
 		`defaults are applied`,
 		{},
 		{ wat: `lol`, much: `neat` },
 		`/state?much=neat&wat=lol`,
+		'defaultParameters',
 	)
 })
 
@@ -68,7 +66,7 @@ test(`race conditions on redirects`, async t => {
 		route: `/state1`,
 		template: {},
 		querystringParameters: [ `wat`, `much` ],
-		defaultQuerystringParameters: { wat: `lol`, much: `neat` },
+		defaultParameters: { wat: `lol`, much: `neat` },
 		activate(context) {
 			assert.deepStrictEqual({ wat: `lol`, much: `neat` }, context.parameters)
 			assert.strictEqual(state.location.get(), `/state1?much=neat&wat=lol`)
@@ -83,7 +81,7 @@ test(`race conditions on redirects`, async t => {
 			route: `/state2`,
 			template: {},
 			querystringParameters: [ `wat`, `much` ],
-			defaultQuerystringParameters: { wat: `lol`, much: `neat` },
+			defaultParameters: { wat: `lol`, much: `neat` },
 			activate(context) {
 				assert.deepStrictEqual({ wat: `waycool`, much: `awesome`, hi: `world` }, context.parameters)
 				assert.strictEqual(state.location.get(), `/state2?hi=world&much=awesome&wat=waycool`)
@@ -126,7 +124,6 @@ test(`default parameters should work for route params too`, async t => {
 	}
 
 	await testWithPropertyName(`defaultParameters`)
-	await testWithPropertyName(`defaultQuerystringParameters`)
 })
 
 test(`default parameters should work for default child route params`, async t => {
@@ -167,7 +164,6 @@ test(`default parameters should work for default child route params`, async t =>
 	}
 
 	await testWithPropertyName(`defaultParameters`)
-	await testWithPropertyName(`defaultQuerystringParameters`)
 })
 
 test(`default parameters on parent states should apply to child state routes`, async t => {
@@ -208,7 +204,6 @@ test(`default parameters on parent states should apply to child state routes`, a
 	}
 
 	await testWithPropertyName(`defaultParameters`)
-	await testWithPropertyName(`defaultQuerystringParameters`)
 })
 
 test(`empty string is a valid default parameter`, async t => {

--- a/test/emitters.js
+++ b/test/emitters.js
@@ -227,7 +227,7 @@ test(`emitting dom api create`, async t => {
 		route: `/state`,
 		template: {},
 		querystringParameters: [ `wat`, `much` ],
-		defaultQuerystringParameters: { wat: `lol`, much: `neat` },
+		defaultParameters: { wat: `lol`, much: `neat` },
 		resolve(data, params) {
 			return Promise.resolve({
 				value: `legit`,


### PR DESCRIPTION
`defaultQuerystringParameters` has been deprecated for a very long time, this PR officially removes it.