### PR TITLE
Remove maintainers section from readme

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -369,11 +369,6 @@ If I use the abstract-state-router on an app where I want to support clients wit
 
 If anyone else has need of this functionality and wants to get keep making progress on it, I'd be happy to help.  Stop by the [chat room](https://discord.gg/G8FrErC) to ask any questions.
 
-# Maintainers
-
-- [TehShrike](https://github.com/TehShrike)
-- [ArtskydJ](https://github.com/ArtskydJ)
-
 # License
 
 [WTFPL](http://wtfpl2.com)


### PR DESCRIPTION
If approved, this will be my 5th commit and 10th line of code changed in the past decade.  I think it's fair to say I'm not a maintainer.

Alternatively, you can boot me from the list and add [others](https://github.com/TehShrike/abstract-state-router/graphs/contributors?from=6%2F8%2F2024).